### PR TITLE
[test] Add validation on change of Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -243,7 +243,7 @@
     {
       "groupName": "spire-images",
       "matchFiles": [
-        "install/kubernetes/cilium/values.yaml.tmpl"
+        "install/kubernetes/Makefile.values"
       ],
       "matchPackageNames": [
         "ghcr.io/spiffe/spire-agent",
@@ -252,12 +252,18 @@
       "matchBaseBranches": [
         "main"
       ],
-      "allowedVersions": ">1.6"
+      "allowedVersions": ">1.6",
+      // generate files for helm chart
+      "postUpgradeTasks": {
+        "commands": ["make -C install/kubernetes"],
+        "fileFilters": ["**/**"],
+        "executionMode": "branch"
+      }
     },
     {
       "groupName": "spire-images",
       "matchFiles": [
-        "install/kubernetes/cilium/values.yaml.tmpl"
+        "install/kubernetes/Makefile.values"
       ],
       "matchPackageNames": [
         "ghcr.io/spiffe/spire-agent",
@@ -266,7 +272,13 @@
       "matchBaseBranches": [
         "v1.14"
       ],
-      "allowedVersions": "<1.7"
+      "allowedVersions": "<1.7",
+      // generate files for helm chart
+      "postUpgradeTasks": {
+        "commands": ["make -C install/kubernetes"],
+        "fileFilters": ["**/**"],
+        "executionMode": "branch"
+      }
     },
     {
       "matchPackageNames": [

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,8 +5,21 @@
     ":gitSignOff",
     "helpers:pinGitHubActionDigests"
   ],
+  // self-hosted configuration
+  "username": "cilium-renovate[bot]",
+  "repositories": ["cilium/tetragon"],
+  // renovate first reads this configuration, then reads the repository
+  // configuration, since we don't split between the self-hosted and the
+  // repository configuration, this can lead to duplicate of some areas of the
+  // config, for example the regex. See:
+  // https://docs.renovatebot.com/self-hosted-configuration/#requireconfig
+  "requireConfig": "ignored",
+  "allowedPostUpgradeCommands": [
+    "^make -C install/kubernetes$",
+    "^go mod vendor$",
+  ],
   // This ensures that the gitAuthor and gitSignOff fields match
-  "gitAuthor": "renovate[bot] <bot@renovateapp.com>",
+  "gitAuthor": "cilium-renovate[bot] <134692979+cilium-renovate[bot]@users.noreply.github.com>",
   "includePaths": [
     ".github/actions/ginkgo/**",
     ".github/actions/set-env-variables/action.yml",

--- a/.github/workflows/renovate-config-validator.yaml
+++ b/.github/workflows/renovate-config-validator.yaml
@@ -1,0 +1,20 @@
+name: Validate Renovate configuration
+
+on:
+  pull_request:
+    paths:
+      - '.github/renovate.json5'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout configuration
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      # this step uses latest renovate slim release
+      - name: Validate configuration
+        run: >
+          docker run --rm --entrypoint "renovate-config-validator"
+          -v "${{ github.workspace }}/.github/renovate.json5":"/renovate.json5"
+          renovate/renovate:slim "/renovate.json5"

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,56 @@
+name: Renovate
+on:
+  # running every two hours from 9h to 19h UTC on every working day
+  schedule:
+    - cron: '0 9-19/2 * * 1-5'
+  # allow to manually trigger this workflow
+  workflow_dispatch:
+    inputs:
+      renovate_log_level_debug:
+        type: boolean
+        default: true
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/renovate.json5'
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    env:
+      buildx_version: 'v0.10.5'
+    steps:
+      # we need special permission to be able to operate renovate (view, list,
+      # create issues, PR, etc.) and we use a GitHub application with fine
+      # grained permissions installed in the repository for that.
+      - name: Get token
+        id: get_token
+        uses: cilium/actions-app-token@61a6271ce92ba02f49bf81c755685d59fb25a59a # v0.21.1
+        with:
+          APP_PEM: ${{ secrets.CILIUM_RENOVATE_PEM }}
+          APP_ID: ${{ secrets.CILIUM_RENOVATE_APP_ID }}
+
+      # postUpgradeTasks's commands shorter and understandable.
+      - name: Create and set permissions for install buildx bash script
+        run: |
+          echo '#!/bin/bash' > /tmp/install-buildx
+          echo 'DIR="$HOME/.docker/cli-plugins"' >> /tmp/install-buildx
+          echo 'mkdir -p "$DIR" && ln -sf /tmp/docker-buildx "$DIR/docker-buildx"' >> /tmp/install-buildx
+          chmod +x /tmp/install-buildx
+
+      # renovate clones the repository again in its container fs but it needs
+      # the renovate configuration to start.
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@f9c81dddc9b589e4e6ae0326d1e36f6bc415d230 # v39.2.4
+        env:
+          # default to DEBUG log level, this is always useful
+          LOG_LEVEL: ${{ github.event.inputs.renovate_log_level_debug == 'false' && 'INFO' || 'DEBUG' }}
+        with:
+          configurationFile: .github/renovate.json5
+          token: '${{ steps.get_token.outputs.app_token }}'
+          mount-docker-socket: true
+

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -9,7 +9,8 @@ on:
       renovate_log_level_debug:
         type: boolean
         default: true
-
+  pull_request:
+    
 jobs:
   renovate:
     runs-on: ubuntu-latest

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -9,11 +9,6 @@ on:
       renovate_log_level_debug:
         type: boolean
         default: true
-  push:
-    branches:
-      - main
-    paths:
-      - '.github/renovate.json5'
 
 jobs:
   renovate:


### PR DESCRIPTION
This change adds a GHA to validate the Renovate configuration when it is changed inside a PR.
This is analog to the one in the Tetragon repository

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
